### PR TITLE
Helm ready

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -1,7 +1,17 @@
 apiVersion: v2
-name: mongooseim-chart
-description: A Helm chart for MongooseIM in Kubernetes
-
+name: mongooseim
+description: MongooseIM — The best Enterprise Instant Messaging Solution is the one built for your business.
+keywords:
+  - mongooseim
+  - xmpp
+  - messaging
+  - chat
+  - erlang
 type: application
 version: 0.1.0
 appVersion: 3.7.1
+home: https://github.com/esl/MongooseIM
+icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
+maintainers:
+  - name: MongooseIM Team
+    email: mongooseim@erlang-solutions.com

--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -2,22 +2,6 @@ apiVersion: v2
 name: mongooseim-chart
 description: A Helm chart for MongooseIM in Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 3.7.1

--- a/MongooseIM/templates/mongoose-cm.yaml
+++ b/MongooseIM/templates/mongoose-cm.yaml
@@ -7,10 +7,10 @@ metadata:
 data:
   vm.args: |
     ## Name of the node.
-    -name mongooseim
+    -name {{ .Values.nodeName }}
 
     ## Cookie for distributed erlang
-    -setcookie mongooseim
+    -setcookie {{ .Values.nodeCookie }}
 
     ## Enable more processes (10M)
     +P 10000000

--- a/MongooseIM/templates/mongoose-cm.yaml
+++ b/MongooseIM/templates/mongoose-cm.yaml
@@ -10,15 +10,9 @@ data:
     -name mongooseim
 
     ## Cookie for distributed erlang
-    -setcookie ejabberd
+    -setcookie mongooseim
 
-    ## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
-    ## (Disabled by default..use with caution!)
-    ##-heart
-
-    ## Enable kernel poll and a few async threads
-    +K true
-    +A 5
+    ## Enable more processes (10M)
     +P 10000000
 
     ## Increase number of concurrent ports/sockets

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -7,7 +7,7 @@ metadata:
     type: statefulset
 spec:
   serviceName: mongoose
-  replicas: 3
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: mongoose
@@ -19,7 +19,7 @@ spec:
       subdomain: mongoose
       containers:
       - name: mongoose
-        image: mongooseim/mongooseim:kubernetes
+        image: {{ .Values.image.repository}}:{{ .Chart.AppVersion }}
         env:
           - name: MASTER_ORDINAL
             value: "0"

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: mongoose
+  name: mongooseim
   namespace:
   labels:
     type: statefulset
 spec:
-  serviceName: mongoose
+  serviceName: mongooseim
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: mongoose
+      app: mongooseim
   template:
     metadata:
       labels:
-        app: mongoose
+        app: mongooseim
     spec:
-      subdomain: mongoose
+      subdomain: mongooseim
       containers:
-      - name: mongoose
+      - name: mongooseim
         image: {{ .Values.image.repository}}:{{ .Chart.AppVersion }}
         env:
           - name: MASTER_ORDINAL

--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongoose-lb
+  name: mongooseim-lb
   namespace:
   labels:
 spec:
@@ -10,5 +10,5 @@ spec:
     port: 5222
     targetPort: 5222
   selector:
-    app: mongoose
+    app: mongooseim
   type: LoadBalancer

--- a/MongooseIM/templates/mongoose-svc-nodeport.yaml
+++ b/MongooseIM/templates/mongoose-svc-nodeport.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mongoose-nodeport
+  name: mongooseim-nodeport
   namespace:
   labels:
 spec:
@@ -10,5 +10,5 @@ spec:
     port: 5222
     targetPort: 5222
   selector:
-    app: mongoose
+    app: mongooseim
   type: NodePort

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -1,13 +1,8 @@
-# Default values for mongooseim-chart.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 replicaCount: 1
 
 image:
   repository: mongooseim/mongooseim
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []
@@ -15,26 +10,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -43,34 +27,18 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths: []
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 12
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -5,6 +5,9 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+nodeName: mongooseim
+nodeCookie: mongooseim
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/MongoosePush/Chart.yaml
+++ b/MongoosePush/Chart.yaml
@@ -2,22 +2,8 @@ apiVersion: v2
 name: mongoosepush-chart
 description: A Helm chart for MongoosePush in Kubernetes
 
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: 2.1.0

--- a/MongoosePush/Chart.yaml
+++ b/MongoosePush/Chart.yaml
@@ -1,9 +1,15 @@
 apiVersion: v2
-name: mongoosepush-chart
+name: mongoosepush
 description: A Helm chart for MongoosePush in Kubernetes
-
+keywords:
+  - mongoosepush
+  - messaging
+  - push notifications
+  - elixir
 type: application
-
 version: 0.1.0
-
 appVersion: 2.1.0
+home: https://github.com/esl/MongoosePush
+maintainers:
+  - name: MongooseIM Team
+    email: mongooseim@erlang-solutions.com

--- a/MongoosePush/values.yaml
+++ b/MongoosePush/values.yaml
@@ -1,13 +1,8 @@
-# Default values for mongoosepush-chart.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 replicaCount: 1
 
 image:
   repository: mongooseim/mongooseim
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []
@@ -15,26 +10,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
 
 podSecurityContext: {}
-  # fsGroup: 2000
 
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -43,34 +27,18 @@ service:
 ingress:
   enabled: false
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths: []
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 12
   targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
 
 nodeSelector: {}
 


### PR DESCRIPTION
This PR simply takes what we had on https://github.com/esl/mongooseim-kubernetes/tree/mim-helm and polishes it, so as much as that naming conventions are properly set, the latest version of MongooseIM is used, `values.yaml` is useful, and it all passes helm lint.

Next steps, coming incrementally in separate PRs, will be to document the persistent volumes, update the README, and pipeline creating the packages.