### PR TITLE
Build packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           name: Create Packages
           command: |
             helm package MongooseIM/ MongoosePush/ && \
+            git checkout packages -- index.yaml '*.tgz' && \
             helm repo index ./ --url https://esl.github.io/MongooseHelm/
       - run:
           name: Configure Git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2.1
+
+orbs:
+  helm: circleci/helm@1.0.0
+
+jobs:
+  helm-lint:
+    docker:
+      - image: cimg/go:1.15.1
+    steps:
+      - checkout
+      - helm/install-helm-client:
+          version: v3.3.0
+      - run:
+          name: Lint charts
+          command: helm lint MongooseIM/ MongoosePush/
+  packages-deploy:
+    docker:
+      - image: cimg/go:1.15.1
+    steps:
+      - checkout
+      - add_ssh_keys
+      - helm/install-helm-client:
+          version: v3.3.0
+      - run:
+          name: Create Packages
+          command: |
+            helm package MongooseIM/ MongoosePush/ && \
+            helm repo index ./ --url https://esl.github.io/MongooseHelm/
+      - run:
+          name: Configure Git
+          command: |
+            git config --global user.email "mongooseim@erlang-solutions.com"
+            git config --global user.name "Mongoose"
+      - run:
+          name: Generate commit with packages
+          command: |
+            git checkout --orphan tmp && \
+            git rm --cached . -r && \
+            git add *.tgz index.yaml .circleci/config.yml && \
+            git commit -m "Mongoose Charts"
+      - run:
+          name: Update the `packages` branch to point to this commit and push it
+          command: |
+            git checkout packages -f && \
+            git reset tmp --hard && \
+            git branch -D tmp && \
+            git push origin packages --force
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - helm-lint:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: packages
+      - packages-deploy:
+          requires:
+            - helm-lint
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
This PR introduces an automated pipeline to build the helm packages in CircleCI. It is for now a draft, that will become a common PR once #1 is merged, so that then this can be reviewed and merged.

This CircleCI configuration will basically run `helm lint` as a minimum testing for all pushes, as helm hub requires this linter to always pass. If what's being run is master, packages and the index will be rebuilt and pushed to an orphan branch called `packages`. This GitHub repo is at the moment configured to expose this `packages` branch as a github page. This github page link is what will be registered with helm hub, once everything is ready.