### PR TITLE
Update to MongooseIM 4.0.0 with extra config options 

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - erlang
 type: application
 version: 0.1.0
-appVersion: 3.7.1
+appVersion: 4.0.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 4.0.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png

--- a/MongooseIM/mongooseim.toml
+++ b/MongooseIM/mongooseim.toml
@@ -1,0 +1,322 @@
+[general]
+  loglevel = "warning"
+  hosts = ["localhost"]
+  registration_timeout = "infinity"
+  language = "en"
+  all_metrics_are_global = false
+  sm_backend = "mnesia"
+  max_fsm_queue = 1000
+
+[[listen.http]]
+  port = 5280
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mod_bosh]]
+    host = "_"
+    path = "/http-bind"
+
+  [[listen.http.handlers.mod_websockets]]
+    host = "_"
+    path = "/ws-xmpp"
+
+    [listen.http.handlers.mod_websockets.service]
+      access = "all"
+      shaper_rule = "fast"
+      password = "secret"
+
+[[listen.http]]
+  port = 5285
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+  tls.certfile = "priv/ssl/fake_cert.pem"
+  tls.keyfile = "priv/ssl/fake_key.pem"
+  tls.password =  ""
+
+  [[listen.http.handlers.mod_bosh]]
+    host = "_"
+    path = "/http-bind"
+
+  [[listen.http.handlers.mod_websockets]]
+    host = "_"
+    path = "/ws-xmpp"
+
+[[listen.http]]
+  ip_address = "127.0.0.1"
+  port = 8088
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_api_admin]]
+    host = "localhost"
+    path = "/api"
+
+[[listen.http]]
+  port = 8089
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+  protocol.compress = true
+  tls.certfile = "priv/ssl/fake_cert.pem"
+  tls.keyfile = "priv/ssl/fake_key.pem"
+  tls.password =  ""
+
+  [[listen.http.handlers.lasse_handler]]
+    host = "_"
+    path = "/api/sse"
+    module = "mongoose_client_api_sse"
+
+  [[listen.http.handlers.mongoose_client_api_messages]]
+    host = "_"
+    path = "/api/messages/[:with]"
+
+  [[listen.http.handlers.mongoose_client_api_contacts]]
+    host = "_"
+    path = "/api/contacts/[:jid]"
+
+  [[listen.http.handlers.mongoose_client_api_rooms]]
+    host = "_"
+    path = "/api/rooms/[:id]"
+
+  [[listen.http.handlers.mongoose_client_api_rooms_config]]
+    host = "_"
+    path = "/api/rooms/[:id]/config"
+
+  [[listen.http.handlers.mongoose_client_api_rooms_users]]
+    host = "_"
+    path = "/api/rooms/:id/users/[:user]"
+
+  [[listen.http.handlers.mongoose_client_api_rooms_messages]]
+    host = "_"
+    path = "/api/rooms/[:id]/messages"
+
+  [[listen.http.handlers.cowboy_swagger_redirect_handler]]
+    host = "_"
+    path = "/api-docs"
+
+  [[listen.http.handlers.cowboy_swagger_json_handler]]
+    host = "_"
+    path = "/api-docs/swagger.json"
+
+  [[listen.http.handlers.cowboy_static]]
+    host = "_"
+    path = "/api-docs/[...]"
+    type = "priv_dir"
+    app = "cowboy_swagger"
+    content_path = "swagger"
+
+[[listen.http]]
+  ip_address = "127.0.0.1"
+  port = 5288
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_api]]
+    host = "localhost"
+    path = "/api"
+    handlers = ["mongoose_api_metrics", "mongoose_api_users"]
+
+[[listen.c2s]]
+  port = 5222
+  tls.certfile = "priv/ssl/fake_server.pem"
+  tls.mode = "starttls"
+  access = "c2s"
+  shaper = "c2s_shaper"
+  max_stanza_size = 65536
+
+[[listen.s2s]]
+  port = 5269
+  shaper = "s2s_shaper"
+  max_stanza_size = 131072
+
+[[listen.service]]
+  port = 8888
+  access = "all"
+  shaper_rule = "fast"
+  ip_address = "127.0.0.1"
+  password = "secret"
+
+[auth]
+  methods = ["internal"]
+  sasl_external = ["standard"]
+
+#[outgoing_pools.redis.global_distrib]
+#  scope = "single_host"
+#  host = "localhost"
+#  workers = 10
+#
+#[outgoing_pools.rdbms.default]
+#  scope = "global"
+#  workers = 5
+#
+#  [outgoing_pools.rdbms.default.connection]
+#    driver = "pgsql"
+#    host = "localhost"
+#    database = "ejabberd"
+#    username = "ejabberd"
+#    password = "mongooseim_secret"
+#    tls.required = true
+#    tls.verify_peer = true
+#    tls.cacertfile = "priv/ssl/cacert.pem"
+#    tls.server_name_indication = false
+
+[services.service_admin_extra]
+  submods = ["node", "accounts", "sessions", "vcard", "gdpr", "upload",
+             "roster", "last", "private", "stanza", "stats"]
+
+[services.service_mongoose_system_metrics]
+  initial_report = 300_000
+  periodic_report = 10_800_000
+
+[modules.mod_adhoc]
+
+[modules.mod_disco]
+  users_can_see_hidden_services = false
+
+[modules.mod_commands]
+
+[modules.mod_muc_commands]
+
+[modules.mod_muc_light_commands]
+
+[modules.mod_last]
+
+[modules.mod_stream_management]
+
+[modules.mod_offline]
+  access_max_user_messages = "max_user_offline_messages"
+
+[modules.mod_privacy]
+
+[modules.mod_blocking]
+
+[modules.mod_private]
+
+[modules.mod_register]
+  welcome_message = {body = "", subject = ""}
+  ip_access = [
+    {address = "127.0.0.0/8", policy = "allow"},
+    {address = "0.0.0.0/0", policy = "deny"}
+  ]
+  access = "register"
+
+[modules.mod_roster]
+
+[modules.mod_sic]
+
+[modules.mod_vcard]
+  host = "vjud.@HOST@"
+
+[modules.mod_bosh]
+
+[modules.mod_carboncopy]
+
+[shaper.normal]
+  max_rate = 1000
+
+[shaper.fast]
+  max_rate = 50_000
+
+[shaper.mam_shaper]
+  max_rate = 1
+
+[shaper.mam_global_shaper]
+  max_rate = 1000
+
+[acl]
+  local = [
+    {user_regexp = ""}
+  ]
+
+[access]
+  max_user_sessions = [
+    {acl = "all", value = 10}
+  ]
+
+  max_user_offline_messages = [
+    {acl = "admin", value = 5000},
+    {acl = "all", value = 100}
+  ]
+
+  local = [
+    {acl = "local", value = "allow"}
+  ]
+
+  c2s = [
+    {acl = "blocked", value = "deny"},
+    {acl = "all", value = "allow"}
+  ]
+
+  c2s_shaper = [
+    {acl = "admin", value = "none"},
+    {acl = "all", value = "normal"}
+  ]
+
+  s2s_shaper = [
+    {acl = "all", value = "fast"}
+  ]
+
+  muc_admin = [
+    {acl = "admin", value = "allow"}
+  ]
+
+  muc_create = [
+    {acl = "local", value = "allow"}
+  ]
+
+  muc = [
+    {acl = "all", value = "allow"}
+  ]
+
+  register = [
+    {acl = "all", value = "allow"}
+  ]
+
+  mam_set_prefs = [
+    {acl = "all", value = "default"}
+  ]
+
+  mam_get_prefs = [
+    {acl = "all", value = "default"}
+  ]
+
+  mam_lookup_messages = [
+    {acl = "all", value = "default"}
+  ]
+
+  mam_set_prefs_shaper = [
+    {acl = "all", value = "mam_shaper"}
+  ]
+
+  mam_get_prefs_shaper = [
+    {acl = "all", value = "mam_shaper"}
+  ]
+
+  mam_lookup_messages_shaper = [
+    {acl = "all", value = "mam_shaper"}
+  ]
+
+  mam_set_prefs_global_shaper = [
+    {acl = "all", value = "mam_global_shaper"}
+  ]
+
+  mam_get_prefs_global_shaper = [
+    {acl = "all", value = "mam_global_shaper"}
+  ]
+
+  mam_lookup_messages_global_shaper = [
+    {acl = "all", value = "mam_global_shaper"}
+  ]
+
+[s2s]
+  use_starttls = "optional"
+  certfile = "priv/ssl/fake_server.pem"
+  default_policy = "deny"
+  outgoing.port = 5269
+
+#[[host_config]]
+#  host = "anonymous.localhost"
+#
+#  [host_config.auth]
+#    methods = ["anonymous"]
+#    anonymous.allow_multiple_connections = true
+#    anonymous.protocol = "both"

--- a/MongooseIM/templates/mongoose-cm.yaml
+++ b/MongooseIM/templates/mongoose-cm.yaml
@@ -5,24 +5,8 @@ metadata:
   labels:
     app: mongooseim
 data:
-  vm.args: |
-    ## Name of the node.
-    -name {{ .Values.nodeName }}
-
-    ## Cookie for distributed erlang
-    -setcookie {{ .Values.nodeCookie }}
-
-    ## Enable more processes (10M)
-    +P 10000000
-
-    ## Increase number of concurrent ports/sockets
-    -env ERL_MAX_PORTS 250000
-
-    ## Tweak GC to run more often
-    -env ERL_FULLSWEEP_AFTER 2
-
-    ## With lager sasl reports are redundant so turn them off
-    -sasl sasl_error_logger false
-
-    -kernel inet_dist_listen_min 9100
-    -kernel inet_dist_listen_max 9100
+  {{- $root := . }}
+  {{- range tuple "vm.args" "mongooseim.toml" }}
+  {{ . }}: |-
+    {{- tpl ($root.Files.Get .) $root | nindent 4}}
+  {{- end }}

--- a/MongooseIM/templates/mongoose-svc-nodeport.yaml
+++ b/MongooseIM/templates/mongoose-svc-nodeport.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.nodeport.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
   selector:
     app: mongooseim
   type: NodePort
+{{ end }}

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -48,3 +48,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+nodeport:
+  enabled: false

--- a/MongooseIM/vm.args
+++ b/MongooseIM/vm.args
@@ -1,0 +1,20 @@
+## Name of the node.
+-name {{ .Values.nodeName }}
+
+## Cookie for distributed erlang
+-setcookie {{ .Values.nodeCookie }}
+
+## Enable more processes (10M)
++P 10000000
+
+## Increase number of concurrent ports/sockets
+-env ERL_MAX_PORTS 250000
+
+## Tweak GC to run more often
+-env ERL_FULLSWEEP_AFTER 2
+
+## With lager sasl reports are redundant so turn them off
+-sasl sasl_error_logger false
+
+-kernel inet_dist_listen_min 9100
+-kernel inet_dist_listen_max 9100


### PR DESCRIPTION
- Use the new 4.0.0 docker image with the TOML configuration file.
- Make it easier to change `mongooseim.toml` by including it in the config map. Also: process it with heml templates, so we could put some config options in `values.yaml`.
- Disable the `nodeport` service by default as in the typical setup only the load balancer is needed. What is more, our Google Cloud Platform setup prevents connection to higher port numbers that the nodeport service offers.

TO DO next:
- Clean up `values.yaml`
- Make it possible to run several clusters at the same time on the same cloud env by templating the `yaml` files for Kubernetes.