### PR TITLE
Update mim to 5.1.0

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.3.4
-appVersion: 5.0.0
+version: 0.3.5
+appVersion: 5.1.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -30,6 +30,7 @@
   port = 5285
   transport.num_acceptors = 10
   transport.max_connections = 1024
+  tls.verify_mode = "none"
   tls.certfile = "priv/ssl/fake_cert.pem"
   tls.keyfile = "priv/ssl/fake_key.pem"
   tls.password =  ""
@@ -52,58 +53,23 @@
     host = "localhost"
     path = "/api"
 
+  [[listen.http.handlers.mongoose_domain_handler]]
+    host = "localhost"
+    path = "/api"
+
 [[listen.http]]
   port = 8089
   transport.num_acceptors = 10
   transport.max_connections = 1024
   protocol.compress = true
+  tls.verify_mode = "none"
   tls.certfile = "priv/ssl/fake_cert.pem"
   tls.keyfile = "priv/ssl/fake_key.pem"
   tls.password =  ""
 
-  [[listen.http.handlers.lasse_handler]]
+  [[listen.http.handlers.mongoose_client_api]]
     host = "_"
-    path = "/api/sse"
-    module = "mongoose_client_api_sse"
-
-  [[listen.http.handlers.mongoose_client_api_messages]]
-    host = "_"
-    path = "/api/messages/[:with]"
-
-  [[listen.http.handlers.mongoose_client_api_contacts]]
-    host = "_"
-    path = "/api/contacts/[:jid]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms]]
-    host = "_"
-    path = "/api/rooms/[:id]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_config]]
-    host = "_"
-    path = "/api/rooms/[:id]/config"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_users]]
-    host = "_"
-    path = "/api/rooms/:id/users/[:user]"
-
-  [[listen.http.handlers.mongoose_client_api_rooms_messages]]
-    host = "_"
-    path = "/api/rooms/[:id]/messages"
-
-  [[listen.http.handlers.cowboy_swagger_redirect_handler]]
-    host = "_"
-    path = "/api-docs"
-
-  [[listen.http.handlers.cowboy_swagger_json_handler]]
-    host = "_"
-    path = "/api-docs/swagger.json"
-
-  [[listen.http.handlers.cowboy_static]]
-    host = "_"
-    path = "/api-docs/[...]"
-    type = "priv_dir"
-    app = "cowboy_swagger"
-    content_path = "swagger"
+    path = "/api"
 
 [[listen.http]]
   ip_address = "127.0.0.1"
@@ -114,15 +80,16 @@
   [[listen.http.handlers.mongoose_api]]
     host = "localhost"
     path = "/api"
-    handlers = ["mongoose_api_metrics", "mongoose_api_users"]
 
 [[listen.c2s]]
   port = 5222
-  tls.certfile = "priv/ssl/fake_server.pem"
-  tls.mode = "starttls"
+  zlib = 10_000
   access = "c2s"
   shaper = "c2s_shaper"
   max_stanza_size = 65536
+  tls.verify_mode = "none"
+  tls.certfile = "priv/ssl/fake_server.pem"
+  tls.dhfile = "priv/ssl/fake_dh_server.pem"
 
 [[listen.s2s]]
   port = 5269
@@ -137,14 +104,14 @@
   password = "secret"
 
 [auth]
-  methods = ["internal"]
-  sasl_external = ["standard"]
 
-#[outgoing_pools.redis.global_distrib]
-#  scope = "single_host"
-#  host = "localhost"
-#  workers = 10
-#
+  [auth.password]
+    format = "scram"
+    hash = ["sha256"]
+    scram_iterations = 64
+
+  [auth.internal]
+
 #[outgoing_pools.rdbms.default]
 #  scope = "global"
 #  workers = 5
@@ -152,21 +119,16 @@
 #  [outgoing_pools.rdbms.default.connection]
 #    driver = "pgsql"
 #    host = "localhost"
-#    database = "ejabberd"
-#    username = "ejabberd"
+#    database = "mongooseim"
+#    username = "mongooseim"
 #    password = "mongooseim_secret"
 #    tls.required = true
-#    tls.verify_peer = true
 #    tls.cacertfile = "priv/ssl/cacert.pem"
-#    tls.server_name_indication = false
+#    tls.server_name_indication.enabled = false
 
 [services.service_admin_extra]
-  submods = ["node", "accounts", "sessions", "vcard", "gdpr", "upload",
-             "roster", "last", "private", "stanza", "stats"]
 
 [services.service_mongoose_system_metrics]
-  initial_report = 300_000
-  periodic_report = 10_800_000
 
 [modules.mod_adhoc]
 
@@ -191,9 +153,9 @@
 [modules.mod_blocking]
 
 [modules.mod_private]
+  backend = "mnesia"
 
 [modules.mod_register]
-  welcome_message = {body = "", subject = ""}
   ip_access = [
     {address = "127.0.0.0/8", policy = "allow"},
     {address = "0.0.0.0/0", policy = "deny"}


### PR DESCRIPTION
```bash
➜  MongooseIM git:(update-to-5.1.0) ✗ kubectl get pods
NAME           READY   STATUS    RESTARTS   AGE
mongooseim-0   1/1     Running   0          3m32s
mongooseim-1   1/1     Running   0          2m21s
mongooseim-2   1/1     Running   0          75s
➜  MongooseIM git:(update-to-5.1.0) ✗ kubectl exec mongooseim-0 -- /usr/lib/mongooseim/bin/mongooseimctl mnesia running_db_nodes
['mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local']
➜  MongooseIM git:(update-to-5.1.0) ✗ kubectl exec mongooseim-1 -- /usr/lib/mongooseim/bin/mongooseimctl mnesia running_db_nodes
['mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local']
➜  MongooseIM git:(update-to-5.1.0) ✗ kubectl exec mongooseim-2 -- /usr/lib/mongooseim/bin/mongooseimctl mnesia running_db_nodes
['mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local',
 'mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local']

➜  MongooseIM git:(update-to-5.1.0) ✗ kubectl exec --stdin --tty mongooseim-0 -- /bin/bash
root@mongooseim-0:/# ./lib/mongooseim/bin/mongooseim version

      ..';:cc:,
     ,ooooooo''l:'
      ;ooooooooool.
      .oooooooc,.
      .oooooo:
      ,oooooo,
      cooooooo.
     .ooooooooc
     :ooooooooo.
    .oooooooooooc;.
    'ooooooooo:,coo,
    :ooooooooo:..;oo.  ..
   .oooooooooooolcoo. :ooc
   ,ooooooooooooooooc .,,.     .:oo;
   :ooooooooooooooool   ,.    .oocloc  .;ooo;
  .loooooooooooooooo:   'ol'  .oo..oo;;oo;,co:
  .ooooooooooooooooo,    ,oo: .oo. :oool.  .oo.
  .ooooooooollooooool.    loo..lo. .cl:.   'ol.
  .looooc.     ..,loooc. .ooo' ..          .'.
   'oooo.          ..''..looc
    ;oool,..       ...;cooo:
     .;cooooollllloooool;..
         ..'',,;;,,'..

MongooseIM version 5.1.0
root@mongooseim-0:/# ./lib/mongooseim/bin/mongooseim debug
--------------------------------------------------------------------

IMPORTANT: we will attempt to attach an INTERACTIVE shell
to an already running ejabberd node.
If an ERROR is printed, it means the connection was not successful.
You can interact with the ejabberd node if you know how to use it.
Please be extremely cautious with your actions,
and exit immediately if you are not completely sure.

To detach this shell from ejabberd, press:
  control+c, control+c

--------------------------------------------------------------------
Press 'Enter' to continue


Exec: /lib/mongooseim/erts-13.0/bin/erl -name debug-3cf4dbea-mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local -setcookie mongooseim -remsh mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local -hidden -args_file /lib/mongooseim/etc/vm.dist.args
Erlang/OTP 25 [erts-13.0] [source] [64-bit] [smp:6:6] [ds:6:6:10] [async-threads:1] [jit:ns]

Eshell V13.0  (abort with ^G)
(mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local)1> mongoose_domain_api:get_all_static().
[{<<"localhost">>,<<"localhost">>}]
(mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local)2>

```