### PR TITLE
Allow to override tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.sw*
+*.tgz
+.DS_Store

--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: 5.1.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png

--- a/MongooseIM/README.md
+++ b/MongooseIM/README.md
@@ -44,6 +44,16 @@ NOTE: `vmConfig` and `mimConfig` should be given using helm's `--set-file` direc
 helm install mim mongoose/mongooseim --set-file mimConfig=<path-to-mim-toml-config-file.toml>
 ```
 
+# Install custom application version
+
+Sometimes you want to use a non-default Docker image. It is possible by specifying `image.tag` value:
+
+```sh
+helm install "my-mongooseim" mongoose/mongooseim --set image.tag=PR-3796
+```
+
+Be aware, that the APP VERSION in the output of the `helm list` would not be correct in this case.
+
 ## Monitoring results
 
 When working with a Kubernetes cluster it's convenient to see the results of the actions taken. In order to do that, let's start a terminal window and run:

--- a/MongooseIM/templates/NOTES.txt
+++ b/MongooseIM/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thank you for installing MongooseIM {{ .Chart.AppVersion }}
+Thank you for installing MongooseIM {{or .Values.image.tag .Chart.AppVersion}}
 
 This chart defines MongooseIM as a StatefulSet, which claims persistent volumes. When the chart is uninstalled, following kubernetes' policy, these persistent volumes are not reclaimed, so that information is not lost. Information about automating this can be found here: https://github.com/kubernetes/kubernetes/issues/55045
 

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -19,7 +19,7 @@ spec:
       subdomain: mongooseim
       containers:
       - name: mongooseim
-        image: {{ .Values.image.repository}}:{{ .Chart.AppVersion }}
+        image: {{ .Values.image.repository }}:{{or .Values.image.tag .Chart.AppVersion}}
         env:
           - name: MASTER_ORDINAL
             value: "0"

--- a/MongoosePush/Chart.yaml
+++ b/MongoosePush/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - push notifications
   - elixir
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 2.1.0
 home: https://github.com/esl/MongoosePush
 maintainers:

--- a/MongoosePush/templates/mongoosepush.yaml
+++ b/MongoosePush/templates/mongoosepush.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: mpush
-        image: {{ .Values.image.repository }}:{{ .Chart.AppVersion }}
+        image: {{ .Values.image.repository }}:{{or .Values.image.tag .Chart.AppVersion}}
         imagePullPolicy: IfNotPresent
         env:
         - name: PUSH_APNS_ENABLED


### PR DESCRIPTION
Allow to override tag.
It should helm using the same chart version for multiple version of the MIM code (i.e. for private installations, or CI builds).

Helm allows to override AppVersion at the build time, but not at the install time (not cool).
So, we actually start using `image.tag`, which was here in the values, but it was not working, because it was not used in the templates.