### PR TITLE
Update MIM to 6.0.0

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.3.6
-appVersion: 5.1.0
+version: 0.3.7
+appVersion: 6.0.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -49,11 +49,7 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_api_admin]]
-    host = "localhost"
-    path = "/api"
-
-  [[listen.http.handlers.mongoose_domain_handler]]
+  [[listen.http.handlers.mongoose_admin_api]]
     host = "localhost"
     path = "/api"
 
@@ -73,13 +69,38 @@
 
 [[listen.http]]
   ip_address = "127.0.0.1"
-  port = 5288
+  port = 5551
   transport.num_acceptors = 10
   transport.max_connections = 1024
 
-  [[listen.http.handlers.mongoose_api]]
+  [[listen.http.handlers.mongoose_graphql_handler]]
     host = "localhost"
-    path = "/api"
+    path = "/api/graphql"
+    schema_endpoint = "admin"
+    username = "admin"
+    password = "secret"
+
+[[listen.http]]
+  ip_address = "0.0.0.0"
+  port = 5541
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_graphql_handler]]
+    host = "_"
+    path = "/api/graphql"
+    schema_endpoint = "domain_admin"
+
+[[listen.http]]
+  ip_address = "0.0.0.0"
+  port = 5561
+  transport.num_acceptors = 10
+  transport.max_connections = 1024
+
+  [[listen.http.handlers.mongoose_graphql_handler]]
+    host = "_"
+    path = "/api/graphql"
+    schema_endpoint = "user"
 
 [[listen.c2s]]
   port = 5222
@@ -134,12 +155,6 @@
 
 [modules.mod_disco]
   users_can_see_hidden_services = false
-
-[modules.mod_commands]
-
-[modules.mod_muc_commands]
-
-[modules.mod_muc_light_commands]
 
 [modules.mod_last]
 


### PR DESCRIPTION
Updating MIM version to 6.0.0.
```
januszjakubiec@MacBook-Pro-administrator-3 mongooseim % kubectl get pods
NAME           READY   STATUS    RESTARTS   AGE
mongooseim-0   1/1     Running   1          6h19m
mongooseim-1   1/1     Running   0          18m
mongooseim-2   1/1     Running   0          17m
januszjakubiec@MacBook-Pro-administrator-3 etc % kubectl exec mongooseim-1 -- /usr/lib/mongooseim/bin/mongooseimctl mnesia systemInfo --keys '["running_db_nodes"]'
{
  "data" : {
    "mnesia" : {
      "systemInfo" : [
        {
          "result" : [
            "mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local",
            "mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local",
            "mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local"
          ],
          "key" : "running_db_nodes"
        }
      ]
    }
  }
}
```