### PR TITLE
Update various configuration options

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: 6.1.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png

--- a/MongooseIM/README.md
+++ b/MongooseIM/README.md
@@ -32,11 +32,15 @@ To uninstall, simply run `helm uninstall my-mongooseim`, where `my-mongooseim` i
 |--------------------|------------------------------------------------------|--------------|
 | `nodeName`         | Name of the nodes as containers                      | `mongooseim` |
 | `nodeCookie`       | Cookie to be used by the BEAM                        | `mongooseim` |
+| `nodeSelector`     | [Node selector](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/) for the statefulset | not set |
 | `replicaCount`     | Default number of replicas to be clustered           | `1`          |
 | `loadBalancerIP`   | Exposed external IP address for the Load Balancer, it exposes the XMPP TCP interface | not set (will be automatically assigned) |
+| `loadBalancerAnnotations` | Additional annotations for the load balancer, e.g. to bind it to an AWS Elastic IP | not set |
 | `mimConfig`        | User-given `mongooseim.toml` configuration file      | not set (internal default, check sources) |
 | `vmConfig`         | User-given `vm.args` file (used for tweaking the Erlang VM itself) | not set (internal default, check sources) |
 | `nodeport.enabled` | Whether the k8s nodeport service is desired          | `false`      |
+| `rolloutId`        | Set it to a new value (e.g. random) to force rolling update with `helm upgrade` | not set - rolling update is performed only if the YAML files change |
+| `tlsCertSecret` | [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/) with the certificates referenced in `mongooseim.toml`. All files will be mounted in `priv/ssl`, replacing the default fake certificates, which should **not** be used in a production setup. | not set|
 
 NOTE: `vmConfig` and `mimConfig` should be given using helm's `--set-file` directive, as below:
 

--- a/MongooseIM/templates/NOTES.txt
+++ b/MongooseIM/templates/NOTES.txt
@@ -11,4 +11,4 @@ To learn more about the release, try:
 
 Or go to https://github.com/esl/MongooseIM
 
-(c) 2020 Erlang Solutions Ltd.
+(c) 2023 Erlang Solutions Ltd.

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -17,6 +17,10 @@ spec:
         app: mongooseim
     spec:
       subdomain: mongooseim
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       containers:
       - name: mongooseim
         image: {{ .Values.image.repository }}:{{or .Values.image.tag .Chart.AppVersion}}

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   serviceName: mongooseim
   replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: mongooseim
@@ -15,6 +17,10 @@ spec:
     metadata:
       labels:
         app: mongooseim
+      {{- if .Values.rolloutId }}
+      annotations:
+        rollout: {{ .Values.rolloutId }}
+      {{- end }}
     spec:
       subdomain: mongooseim
       {{- if .Values.nodeSelector }}
@@ -58,10 +64,20 @@ spec:
           mountPath: /member
         - name: mnesia
           mountPath: /var/lib/mongooseim
+        {{- if .Values.tlsCertSecret }}
+        - name: tls
+          mountPath: /usr/lib/mongooseim/priv/ssl
+          readOnly: true
+        {{- end }}
       volumes:
       - name: config-map
         configMap:
           name: mongooseim
+      {{- if .Values.tlsCertSecret }}
+      - name: tls
+        secret:
+          secretName: {{ .Values.tlsCertSecret }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: mnesia

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -42,6 +42,12 @@ spec:
           containerPort: 5280
         - name: erlang-dist
           containerPort: 9100
+        - name: gql-admin
+          containerPort: 5551
+        - name: gql-dom-admin
+          containerPort: 5541
+        - name: gql-user
+          containerPort: 5561
         readinessProbe:
           tcpSocket:
             port: c2s

--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -6,9 +6,18 @@ metadata:
   labels:
 spec:
   ports:
-  - protocol: TCP
+  - name: c2s
+    protocol: TCP
     port: 5222
     targetPort: 5222
+  - name: gql-dom-admin
+    protocol: TCP
+    port: 5541
+    targetPort: 5541
+  - name: gql-user
+    protocol: TCP
+    port: 5561
+    targetPort: 5561
   selector:
     app: mongooseim
   type: LoadBalancer

--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: mongooseim-lb
   namespace:
+  {{- if .Values.loadBalancerAnnotations }}
+  annotations:
+{{ toYaml .Values.loadBalancerAnnotations | indent 4 }}
+  {{- end }}
   labels:
 spec:
   ports:
@@ -21,4 +25,6 @@ spec:
   selector:
     app: mongooseim
   type: LoadBalancer
+  {{- if .Values.LoadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
+  {{- end }}

--- a/MongooseIM/templates/mongoose-svc.yaml
+++ b/MongooseIM/templates/mongoose-svc.yaml
@@ -19,8 +19,17 @@ spec:
     port: 5280
     targetPort: 5280
   - name: erlang-dist
-    targetPort: 9100
     port: 9100
+    targetPort: 9100
+  - name: gql-admin
+    port: 5551
+    targetPort: 5551
+  - name: gql-dom-admin
+    port: 5541
+    targetPort: 5541
+  - name: gql-user
+    port: 5561
+    targetPort: 5561
   clusterIP: None
   selector:
     app: mongooseim

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -50,9 +50,13 @@ tolerations: []
 affinity: {}
 
 loadBalancerIP: ""
+loadBalancerAnnotations: {}
 
 nodeport:
   enabled: false
 
 vmConfig: ""
 mimConfig: ""
+
+rolloutId: ""
+tlsCertSecret: {}


### PR DESCRIPTION
The goal is to update the chart for a production-ready setup.

Main changes:
- Expose GraphQL API
- Provide TLS certificates with secrets
- Enable rolling update
- Add `nodeSelector` and `loadBalancerAnnotations`