### PR TITLE
Configure MongooseIM with RDBMS and CETS

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -1,3 +1,7 @@
+{{ if and (eq "cets" .Values.volatileDatabase) (ne "rdbms" .Values.persistentDatabase) -}}
+{{ required "CETS requires RDBMS for node discovery" "" -}}
+{{ end -}}
+
 [general]
   loglevel = "warning"
   default_server_domain = "localhost"
@@ -5,7 +9,9 @@
   registration_timeout = "infinity"
   language = "en"
   all_metrics_are_global = false
-  sm_backend = "mnesia"
+  sm_backend = "{{ .Values.volatileDatabase }}"
+  component_backend = "{{ .Values.volatileDatabase }}"
+  s2s_backend = "{{ .Values.volatileDatabase }}"
   max_fsm_queue = 1000
 
 [[listen.http]]
@@ -26,8 +32,8 @@
   transport.num_acceptors = 10
   transport.max_connections = 1024
   tls.verify_mode = "none"
-  tls.certfile = "priv/ssl/fake_cert.pem"
-  tls.keyfile = "priv/ssl/fake_key.pem"
+  tls.certfile = "priv/ssl/{{ .Values.certs.fullChain }}"
+  tls.keyfile = "priv/ssl/{{ .Values.certs.privKey }}"
   tls.password = ""
 
   [[listen.http.handlers.mod_bosh]]
@@ -54,8 +60,8 @@
   transport.max_connections = 1024
   protocol.compress = true
   tls.verify_mode = "none"
-  tls.certfile = "priv/ssl/fake_cert.pem"
-  tls.keyfile = "priv/ssl/fake_key.pem"
+  tls.certfile = "priv/ssl/{{ .Values.certs.fullChain }}"
+  tls.keyfile = "priv/ssl/{{ .Values.certs.privKey }}"
   tls.password = ""
 
   [[listen.http.handlers.mongoose_client_api]]
@@ -103,8 +109,7 @@
   shaper = "c2s_shaper"
   max_stanza_size = 65536
   tls.verify_mode = "none"
-  tls.certfile = "priv/ssl/fake_server.pem"
-  tls.dhfile = "priv/ssl/fake_dh_server.pem"
+  tls.certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
 
 [[listen.s2s]]
   port = 5269
@@ -125,21 +130,30 @@
     hash = ["sha256"]
     scram_iterations = 64
 
+  {{ if eq "rdbms" .Values.persistentDatabase -}}
+  [auth.rdbms]
+  {{- else -}}
   [auth.internal]
+  {{- end }}
 
-#[outgoing_pools.rdbms.default]
-#  scope = "global"
-#  workers = 5
-#
-#  [outgoing_pools.rdbms.default.connection]
-#    driver = "pgsql"
-#    host = "localhost"
-#    database = "mongooseim"
-#    username = "mongooseim"
-#    password = "mongooseim_secret"
-#    tls.required = true
-#    tls.cacertfile = "priv/ssl/cacert.pem"
-#    tls.server_name_indication.enabled = false
+[internal_databases.{{ .Values.volatileDatabase }}]
+{{- if eq "rdbms" .Values.persistentDatabase }}
+{{- with .Values.rdbms }}
+
+[outgoing_pools.rdbms.default]
+  scope = "global"
+  workers = 5
+
+  [outgoing_pools.rdbms.default.connection]
+    driver = "{{ .driver }}"
+    host = "{{ .host }}"
+    database = "{{ .database }}"
+    username = "{{ .username }}"
+    password = "{{ .password }}"
+    tls.required = {{ .tls.required }}
+    tls.verify_mode = "none"
+{{- end }}
+{{- end }}
 
 [services.service_admin_extra]
 
@@ -151,18 +165,22 @@
   users_can_see_hidden_services = false
 
 [modules.mod_last]
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_stream_management]
+  backend = "{{ .Values.volatileDatabase }}"
 
 [modules.mod_offline]
   access_max_user_messages = "max_user_offline_messages"
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_privacy]
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_blocking]
 
 [modules.mod_private]
-  backend = "mnesia"
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_register]
   ip_access = [
@@ -174,13 +192,16 @@
 [modules.mod_presence]
 
 [modules.mod_roster]
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_sic]
 
 [modules.mod_vcard]
   host = "vjud.@HOST@"
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_bosh]
+  backend = "{{ .Values.volatileDatabase }}"
 
 [modules.mod_carboncopy]
 
@@ -283,7 +304,7 @@
 
 [s2s]
   use_starttls = "optional"
-  certfile = "priv/ssl/fake_server.pem"
+  certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
   default_policy = "deny"
   outgoing.port = 5269
 

--- a/MongooseIM/templates/NOTES.txt
+++ b/MongooseIM/templates/NOTES.txt
@@ -1,10 +1,14 @@
 Thank you for installing MongooseIM {{or .Values.image.tag .Chart.AppVersion}}
 
+{{- if or (eq .Values.volatileDatabase "mnesia") (eq .Values.persistentDatabase "mnesia") }}
+
 This chart defines MongooseIM as a StatefulSet, which claims persistent volumes. When the chart is uninstalled, following kubernetes' policy, these persistent volumes are not reclaimed, so that information is not lost. Information about automating this can be found here: https://github.com/kubernetes/kubernetes/issues/55045
 
 Removing them manually might be necessary, for example when reinstalling. To remove one such volume, use a command like the following:
   $ kubectl delete persistentvolumeclaim/mnesia-mongooseim-X
 where `X` is the appropriate numeric suffix.
+
+{{- end }}
 
 To learn more about the release, try:
   $ helm get all {{ .Release.Name }}

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -1,3 +1,5 @@
+{{ $mnesia_enabled := or (eq .Values.volatileDatabase "mnesia") (eq .Values.persistentDatabase "mnesia") -}}
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -17,10 +19,8 @@ spec:
     metadata:
       labels:
         app: mongooseim
-      {{- if .Values.rolloutId }}
       annotations:
-        rollout: {{ .Values.rolloutId }}
-      {{- end }}
+        rollout: {{ .Values.rolloutId | default (randAlphaNum 24) }}
     spec:
       subdomain: mongooseim
       {{- if .Values.nodeSelector }}
@@ -31,6 +31,10 @@ spec:
       - name: mongooseim
         image: {{ .Values.image.repository }}:{{or .Values.image.tag .Chart.AppVersion}}
         env:
+          {{- if not $mnesia_enabled }}
+          - name: JOIN_CLUSTER
+            value: "false"
+          {{- end }}
           - name: MASTER_ORDINAL
             value: "0"
           - name: NODE_TYPE
@@ -57,13 +61,15 @@ spec:
         readinessProbe:
           tcpSocket:
             port: c2s
-          initialDelaySeconds: 60
+          initialDelaySeconds: 10
           periodSeconds: 10
         volumeMounts:
         - name: config-map
           mountPath: /member
+        {{- if $mnesia_enabled }}
         - name: mnesia
           mountPath: /var/lib/mongooseim
+        {{- end }}
         {{- if .Values.tlsCertSecret }}
         - name: tls
           mountPath: /usr/lib/mongooseim/priv/ssl
@@ -78,6 +84,7 @@ spec:
         secret:
           secretName: {{ .Values.tlsCertSecret }}
       {{- end }}
+  {{- if $mnesia_enabled }}
   volumeClaimTemplates:
   - metadata:
       name: mnesia
@@ -86,3 +93,4 @@ spec:
       resources:
         requests:
           storage: 1Gi
+  {{- end }}

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -60,3 +60,20 @@ mimConfig: ""
 
 rolloutId: ""
 tlsCertSecret: {}
+
+volatileDatabase: "mnesia"
+persistentDatabase: "mnesia"
+
+rdbms:
+  driver: "pgsql"
+  host: "host.docker.internal"
+  database: "mongooseim"
+  username: "mongooseim"
+  password: "mongooseim_secret"
+  tls:
+    required: "true"
+
+certs:
+  fullChain: "fake_cert.pem"
+  privKey: "fake_key.pem"
+  fullChainWithKey: "fake_server.pem"


### PR DESCRIPTION
Make it possible (and easy) to configure MongooseIM without Mnesia and persistent volumes.

### Default configuration

The default configuration still uses Mnesia, and it can be still installed easily.

For example, I tested the following setup:

```
$ helm install mim-test MongooseIM --set replicaCount=3 --set image.tag=latest
$ helm upgrade mim-test MongooseIM --set replicaCount=3 --set image.tag=latest
$ helm uninstall mim-test
$ kubectl delete pvc --all
```

Thanks to the randomly generated `rolloutId`, the second command triggered a rolling upgrade, starting with the last node. After the upgrade the Psi+ XMPP client could still connect, and all nodes were still clustered.

### RDBMS as persistent DB

Using RDBMS is easier thanks to config templating:

```
$ helm install mim-test MongooseIM --set replicaCount=3 --set image.tag=latest --set persistentDatabase=rdbms --set rdbms.username=myuser --set rdbms.password=mypass
```

Now RDBMS is used instead of Mnesia, but persistent volumes are still used (there is a way to avoid them, but it would require changes in `mongooseim-docker` logic, and it doesn't fix all Mnesia issues anyway). Rolling upgrade was tested, and it worked as expected.

### RDBMS as persistent DB, CETS as volatile DB

The most important novelty is the possibility to use RDBMS with CETS

```
$ helm install mim-test MongooseIM --set replicaCount=3 --set image.tag=latest --set persistentDatabase=rdbms --set rdbms.username=myuser --set rdbms.password=mypass --set volatileDatabase=cets
```

No persistent volumes are created, and CETS clustered correctly, which was checked with `/usr/lib/mongooseim/bin/mongooseimctl cets systemInfo` on all nodes. During rolling upgrade the discovery worked quickly (despite the theoretically possible 5-second delay), and for each node there was less than a second until it saw all other nodes.

### Notes

Certificates are templated to make it possible to provide them without the need for entire `mimConfig`. I think this option is important, because hardcoded fake certificates in the config made it necessary to always replace it with a custom TOML file.

Kubernetes `deployment` is not used instead of `statefulset`. It was tested, and there are following issues:
- Deployment does not provide stable network ID's, and the only way to provide clustering is with IP addresses, which change with each upgrade. This required minor changes in `mongooseim-docker`.
- Node table was growing, making it impossible to start new nodes after a few restarts.
- Deployment requires a separate manifest, and the manifests were becoming complicated.
I think we could experiment with Deployment again when node cleanup is implemented in CETS.


