### PR TITLE
Enable BOSH and Websockets on the load balancer

### DIFF
--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -14,6 +14,10 @@ spec:
     protocol: TCP
     port: 5222
     targetPort: 5222
+  - name: bosh
+    protocol: TCP
+    port: 5280
+    targetPort: 5280
   - name: gql-dom-admin
     protocol: TCP
     port: 5541


### PR DESCRIPTION
This endpoint is used by web clients.