### PR TITLE
Open port 5285 for secure ws/bosh

### DIFF
--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -48,8 +48,10 @@ spec:
           containerPort: 5222
         - name: s2s
           containerPort: 5269
-        - name: bosh
+        - name: bosh-ws
           containerPort: 5280
+        - name: bosh-wss
+          containerPort: 5285
         - name: erlang-dist
           containerPort: 9100
         - name: gql-admin

--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -14,10 +14,14 @@ spec:
     protocol: TCP
     port: 5222
     targetPort: 5222
-  - name: bosh
+  - name: bosh-ws
     protocol: TCP
     port: 5280
     targetPort: 5280
+  - name: bosh-wss
+    protocol: TCP
+    port: 5285
+    targetPort: 5285
   - name: gql-dom-admin
     protocol: TCP
     port: 5541

--- a/MongooseIM/templates/mongoose-svc.yaml
+++ b/MongooseIM/templates/mongoose-svc.yaml
@@ -15,9 +15,12 @@ spec:
   - name: s2s
     port: 5269
     targetPort: 5269
-  - name: bosh
+  - name: bosh-ws
     port: 5280
     targetPort: 5280
+  - name: bosh-wss
+    port: 5285
+    targetPort: 5285
   - name: erlang-dist
     port: 9100
     targetPort: 9100


### PR DESCRIPTION
This is needed for web clients, because browsers enforce wss if the initial page is served over HTTPS.