### PR TITLE
Set publishNotReadyAddresses=true. Wait for DNS at startup

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -137,6 +137,9 @@
   {{- end }}
 
 [internal_databases.{{ .Values.volatileDatabase }}]
+{{ if eq "cets" .Values.volatileDatabase -}}
+  wait_for_dns = true
+{{- end }}
 {{- if eq "rdbms" .Values.persistentDatabase }}
 {{- with .Values.rdbms }}
 

--- a/MongooseIM/templates/mongoose-svc.yaml
+++ b/MongooseIM/templates/mongoose-svc.yaml
@@ -33,6 +33,8 @@ spec:
   - name: gql-user
     port: 5561
     targetPort: 5561
+  # Headless service
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     app: mongooseim


### PR DESCRIPTION
Changes:
- Set publishNotReadyAddresses=true. 
- Wait for node to be resolvable DNS at startup. Uses config option.

See PR for:
- MongooseIM https://github.com/esl/MongooseIM/pull/4163
- CETS https://github.com/esl/cets/pull/39

What works:
- Initial startup works fine, nxdomain error is gone. "requested to disconnect" error is gone.

How to test (clone, checkout first):

```
helm install test-mim MongooseIM --set replicaCount=10 --set image.tag=PR-4163 --set persistentDatabase=rdbms --set rdbms.username=ejabberd --set rdbms.database=ejabberd --set volatileDatabase=cets
```

(only PR-4163 works with this build because of new config options for wait_for_dns).
Nodes are joined:
```
kubectl exec -it mongooseim-0 -- mongooseimctl cets systemInfo
```

And logs are cleaner:
```
kubectl logs mongooseim-0
```

TODO:
- We still see that issue in logs:

```
when=2023-11-09T17:48:58.555563+00:00 level=error what=join_retry reason=lock_aborted pid=<0.17788.0> at=cets_join:join_loop/6:90 local_pid=<0.550.0> remote_pid=<32213.552.0> remote_node=mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local table=cets_cluster_id
when=2023-11-09T17:48:58.632915+00:00 level=error what=join_retry reason=lock_aborted pid=<0.17788.0> at=cets_join:join_loop/6:90 local_pid=<0.550.0> remote_pid=<32213.552.0> remote_node=mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local table=cets_cluster_id
when=2023-11-09T17:48:58.743198+00:00 level=error what=join_retry reason=lock_aborted pid=<0.17788.0> at=cets_join:join_loop/6:90 local_pid=<0.550.0> remote_pid=<32213.552.0> remote_node=mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local table=cets_cluster_id
when=2023-11-09T17:48:58.988527+00:00 level=error what=join_retry reason=lock_aborted pid=<0.17788.0> at=cets_join:join_loop/6:90 local_pid=<0.550.0> remote_pid=<32213.552.0> remote_node=mongooseim@mongooseim-3.mongooseim.default.svc.cluster.local table=cets_cluster_id
```

- More testing for cluster updates.
- Actually tests for CETS for DNS fixes (i.e. test that wait_for_dns works in tests, not just in the real life and manual testing).