### PR TITLE
Allow using IP addresses for clustering and support Deployment

### DIFF
--- a/MongooseIM/templates/mongoose-deploy.yaml
+++ b/MongooseIM/templates/mongoose-deploy.yaml
@@ -1,18 +1,13 @@
-{{ if eq .Values.workloadAPI "StatefulSet" -}}
-{{ $mnesia_enabled := or (eq .Values.volatileDatabase "mnesia") (eq .Values.persistentDatabase "mnesia") -}}
-
+{{ if eq .Values.workloadAPI "Deployment" -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: mongooseim
   namespace:
   labels:
-    type: statefulset
+    app: mongooseim
 spec:
-  serviceName: mongooseim
   replicas: {{ .Values.replicaCount }}
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
       app: mongooseim
@@ -31,24 +26,17 @@ spec:
       containers:
       - name: mongooseim
         image: {{ .Values.image.repository }}:{{or .Values.image.tag .Chart.AppVersion}}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
-          {{- if not $mnesia_enabled }}
           - name: JOIN_CLUSTER
             value: "false"
-          {{- end }}
-          - name: MASTER_ORDINAL
-            value: "0"
           - name: NODE_TYPE
             value: "name"
           - name: NODE_NAME
             value: {{ .Values.nodeName }}
-          {{- if .Values.skipClusterDNS }}
           - name: NODE_HOST
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
-          {{- end }}
         ports:
         - name: epmd
           containerPort: 4369
@@ -76,10 +64,6 @@ spec:
         volumeMounts:
         - name: config-map
           mountPath: /member
-        {{- if $mnesia_enabled }}
-        - name: mnesia
-          mountPath: /var/lib/mongooseim
-        {{- end }}
         {{- if .Values.tlsCertSecret }}
         - name: tls
           mountPath: /usr/lib/mongooseim/priv/ssl
@@ -94,14 +78,5 @@ spec:
         secret:
           secretName: {{ .Values.tlsCertSecret }}
       {{- end }}
-  {{- if $mnesia_enabled }}
-  volumeClaimTemplates:
-  - metadata:
-      name: mnesia
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      resources:
-        requests:
-          storage: 1Gi
-  {{- end }}
-{{- end }}
+      setHostnameAsFQDN: true
+{{ end }}

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -61,6 +61,9 @@ mimConfig: ""
 rolloutId: ""
 tlsCertSecret: {}
 
+workloadAPI: "StatefulSet"
+skipClusterDNS: false
+
 volatileDatabase: "mnesia"
 persistentDatabase: "mnesia"
 


### PR DESCRIPTION
- IP addresses can be used to mitigate issues with DNS
- Deployment has different startup/upgrade strategies, which might be useful