### PR TITLE
Add missing backend option for mod_blocking

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -178,6 +178,7 @@
   backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_blocking]
+  backend = "{{ .Values.persistentDatabase }}"
 
 [modules.mod_private]
   backend = "{{ .Values.persistentDatabase }}"


### PR DESCRIPTION
It should be the same as for `mod_privacy`.