### PR TITLE
Remove service_admin_extra

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -155,8 +155,6 @@
 {{- end }}
 {{- end }}
 
-[services.service_admin_extra]
-
 [services.service_mongoose_system_metrics]
 
 [modules.mod_adhoc]


### PR DESCRIPTION
This PR removes the `services.service_admin_extra` entry from the template configuration file. This change is necessary because this entry is no longer relevant after the removal of legacy CLI commands.

Relates to: https://github.com/esl/MongooseIM/pull/4160