### PR TITLE
Update MongooseIM version to 6.2.0

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.3.9
-appVersion: 6.1.0
+version: 0.4.0
+appVersion: 6.2.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:


### PR DESCRIPTION
Version is updated to `0.4.0` because there is new functionality - config templating and the DB-related options.

Chart tested manually.