### PR TITLE
Dist blocker

### DIFF
--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -102,10 +102,9 @@ pod_disappears_with_users_connected(_Config) ->
     stop_amoc(),
     %% Inspect the session table
     try
-        wait_for_session_count("mongooseim-0", 0)
-    catch _:Reason ->
-        ct:pal("wait_for_session_count failed, ignore until we have a fix in MongooseIM~n"
-               "Reason ~p", [Reason])
+        wait_for_session_count("mongooseim-0", 0),
+        wait_for_session_count("mongooseim-1", 0),
+        wait_for_session_count("mongooseim-2", 0)
     after
         run("kubectl logs mongooseim-0"),
         run("kubectl logs mongooseim-1"),


### PR DESCRIPTION
Tests that PR for MongooseIM: https://github.com/esl/MongooseIM/pull/4234

It is a pretty slow CI task, so merging task splitting PR first could be useful: https://github.com/esl/MongooseHelm/pull/37 

Here is how logs look like during k8s cluster upgrade (long prevent_overlapped_partitions loops are gone):


```
when=2024-03-06T13:20:55.502653+00:00 level=warning what=nodeup pid=<0.429.0> at=cets_discovery:handle_nodeup/2:607 time_since_startup_in_milliseconds=227 connected_nodes=2 remote_node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:20:55.505088+00:00 level=warning what=nodeup pid=<0.429.0> at=cets_discovery:handle_nodeup/2:607 time_since_startup_in_milliseconds=230 connected_nodes=3 remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:21:42.402713+00:00 level=warning what=nodedown pid=<0.429.0> at=cets_discovery:handle_nodedown/2:591 connected_millisecond_duration=46943 time_since_startup_in_milliseconds=47168 connected_nodes=2 remote_node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:21:42.403074+00:00 level=warning what=node_id_node_down reason=noconnection pid=<0.423.0> at=mongoose_start_node_id:handle_info/2:76 remote_pid=<30870.423.0> monitor_ref=#Ref<0.1930485880.2352218113.248549> remote_node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:21:42.403642+00:00 level=warning what=cleaner_nodedown pid=<0.426.0> at=mongoose_cleaner:handle_info/2:56 text="mongoose_cleaner received nodenown event" down_node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:21:47.650407+00:00 level=warning what=nodeup pid=<0.429.0> at=cets_discovery:handle_nodeup/2:607 downtime_millisecond_duration=5248 time_since_startup_in_milliseconds=52416 connected_nodes=3 remote_node=mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:22:33.577327+00:00 level=warning what=cleaner_nodedown pid=<0.426.0> at=mongoose_cleaner:handle_info/2:56 text="mongoose_cleaner received nodenown event" down_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:22:33.577509+00:00 level=warning what=nodedown pid=<0.429.0> at=cets_discovery:handle_nodedown/2:591 connected_millisecond_duration=98107 time_since_startup_in_milliseconds=98337 connected_nodes=2 remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:22:33.577940+00:00 level=warning what=node_id_node_down reason=noconnection pid=<0.423.0> at=mongoose_start_node_id:handle_info/2:76 remote_pid=<30869.423.0> monitor_ref=#Ref<0.1930485880.2352218113.248572> remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:22:38.135954+00:00 level=warning what=nodeup pid=<0.429.0> at=cets_discovery:handle_nodeup/2:607 downtime_millisecond_duration=4559 time_since_startup_in_milliseconds=102896 connected_nodes=3 remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:24:54.111208+00:00 level=error pid=<0.2110.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:24:54.120 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:24:54.190323+00:00 level=error pid=<0.2112.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:24:54.190 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:24:54.207664+00:00 level=error pid=<0.2114.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:24:54.208 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **

when=2024-03-06T13:24:59.212279+00:00 level=error pid=<0.2123.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:24:59.212 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:25:04.193788+00:00 level=error pid=<0.2126.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:25:04.193 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:25:09.199015+00:00 level=error pid=<0.2128.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:25:09.199 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:25:14.197416+00:00 level=error pid=<0.2131.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:25:14.197 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:25:19.201541+00:00 level=error pid=<0.2133.0> at=: unstructured_log="** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **\
" 
13:25:19.201 [error] ** Connection attempt from node 'mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local' rejected. Invalid challenge reply. **
when=2024-03-06T13:25:19.682483+00:00 level=warning what=cleaner_nodedown pid=<0.426.0> at=mongoose_cleaner:handle_info/2:56 text="mongoose_cleaner received nodenown event" down_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:25:19.682790+00:00 level=warning what=node_id_node_down reason=noconnection pid=<0.423.0> at=mongoose_start_node_id:handle_info/2:76 remote_pid=<30869.423.0> monitor_ref=#Ref<0.1930485880.2352218114.233705> remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local 
when=2024-03-06T13:25:19.682537+00:00 level=warning what=nodedown pid=<0.429.0> at=cets_discovery:handle_nodedown/2:591 connected_millisecond_duration=161532 time_since_startup_in_milliseconds=264428 connected_nodes=2 remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local
```