### PR TITLE
Add 5223 port for full-TLS listener

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -111,6 +111,15 @@
   tls.verify_mode = "none"
   tls.certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
 
+[[listen.c2s]]
+  port = 5223
+  access = "c2s"
+  shaper = "c2s_shaper"
+  max_stanza_size = 65536
+  tls.mode = "tls"
+  tls.verify_mode = "none"
+  tls.certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
+
 [[listen.s2s]]
   port = 5269
   shaper = "s2s_shaper"

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -51,6 +51,8 @@ spec:
           containerPort: 4369
         - name: c2s
           containerPort: 5222
+        - name: c2s-tls
+          containerPort: 5223
         - name: s2s
           containerPort: 5269
         - name: bosh-ws

--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -14,6 +14,10 @@ spec:
     protocol: TCP
     port: 5222
     targetPort: 5222
+  - name: c2s-tls
+    protocol: TCP
+    port: 5223
+    targetPort: 5223
   - name: bosh-ws
     protocol: TCP
     port: 5280

--- a/MongooseIM/templates/mongoose-svc-nodeport.yaml
+++ b/MongooseIM/templates/mongoose-svc-nodeport.yaml
@@ -10,6 +10,9 @@ spec:
   - protocol: TCP
     port: 5222
     targetPort: 5222
+  - protocol: TCP
+    port: 5223
+    targetPort: 5223
   selector:
     app: mongooseim
   type: NodePort

--- a/MongooseIM/templates/mongoose-svc.yaml
+++ b/MongooseIM/templates/mongoose-svc.yaml
@@ -12,6 +12,9 @@ spec:
   - name: c2s
     port: 5222
     targetPort: 5222
+  - name: c2s-tls
+    port: 5223
+    targetPort: 5223
   - name: s2s
     port: 5269
     targetPort: 5269


### PR DESCRIPTION
As in the title. The idea is to enable the so called "legacy" TLS, which really should have been the way all along.