### PR TITLE
Don't delete pod with '--force'

### DIFF
--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -100,7 +100,7 @@ pod_disappears_with_users_connected(_Config) ->
     register_users(UserCount),
     run_amoc(UserCount),
     %% Disconnect one node
-    {0, _} = run("kubectl delete pod mongooseim-0 --force"),
+    {0, _} = run("kubectl delete pod mongooseim-0"),
     %% We could also try to upgrade cluster, instead of disconnect
 %   upgrade_3_nodes_cluster(Config),
     run("kubectl wait statefulset mongooseim --for jsonpath=status.availableReplicas=2 --timeout=2m"),


### PR DESCRIPTION
This command was making the tests flaky.
The most likely reason is that there were duplicate instances of MIM running with the same node name, because k8s resources were not cleaned up yet.

MIM logs confirm that:

```
when=2024-03-29T07:51:27.521675+00:00 level=warning what=node_reconnects pid=<0.428.0> at=cets_discovery:handle_receive_start_time/3:681 text="Netsplit recovery. The remote node has been connected to us before." start_time=1711698687360 remote_node=mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local
when=2024-03-29T07:51:27.532234+00:00 level=error what=already_added pid=<0.544.0> at=cets:add_servers/2:692 servers=[<30917.544.0>,<30918.544.0>] pids=[<30917.544.0>] already_added_servers=[<30917.544.0>]
```

If we need to test instant restarts, we can do this with regular tests in MIM, not here with k8s.

The change was verified with the affected test repeated 20 times: https://app.circleci.com/pipelines/github/esl/MongooseHelm/237/workflows/77b03b4f-c388-4e68-b766-42819c11d0f7