### PR TITLE
Add s2s port to load balancer

### DIFF
--- a/MongooseIM/templates/mongoose-svc-lb.yaml
+++ b/MongooseIM/templates/mongoose-svc-lb.yaml
@@ -26,6 +26,10 @@ spec:
     protocol: TCP
     port: 5285
     targetPort: 5285
+  - name: s2s
+    protocol: TCP
+    port: 5269
+    targetPort: 5269
   - name: gql-dom-admin
     protocol: TCP
     port: 5541


### PR DESCRIPTION
Open s2s port by default on the load-balancer