### PR TITLE
Update docker repo and the instrumentation config

### DIFF
--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -8,7 +8,6 @@
   hosts = ["localhost"]
   registration_timeout = "infinity"
   language = "en"
-  all_metrics_are_global = false
   sm_backend = "{{ .Values.volatileDatabase }}"
   component_backend = "{{ .Values.volatileDatabase }}"
   s2s_backend = "{{ .Values.volatileDatabase }}"
@@ -102,6 +101,14 @@
     host = "_"
     path = "/api/graphql"
     schema_endpoint = "user"
+
+[[listen.http]]
+  port = 9091
+  transport.num_acceptors = 10
+
+  [[listen.http.handlers.mongoose_prometheus_handler]]
+    host = "_"
+    path = "/metrics"
 
 [[listen.c2s]]
   port = 5222

--- a/MongooseIM/templates/mongoose-sts.yaml
+++ b/MongooseIM/templates/mongoose-sts.yaml
@@ -67,6 +67,8 @@ spec:
           containerPort: 5541
         - name: gql-user
           containerPort: 5561
+        - name: prometheus
+          containerPort: 9091
         {{- if .Values.resources }}
         {{-   with .Values.resources }}
         resources:

--- a/MongooseIM/templates/mongoose-svc.yaml
+++ b/MongooseIM/templates/mongoose-svc.yaml
@@ -36,6 +36,9 @@ spec:
   - name: gql-user
     port: 5561
     targetPort: 5561
+  - name: prometheus
+    port: 9091
+    targetPort: 9091
   # Headless service
   clusterIP: None
   publishNotReadyAddresses: true

--- a/MongooseIM/values.yaml
+++ b/MongooseIM/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: mongooseim/mongooseim
+  repository: erlangsolutions/mongooseim
   pullPolicy: IfNotPresent
   tag: ""
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ helm template desired-chart --output-dir desired-path
 Where `desired-chart` is the desired chart to obtain (MongooseIM or MongoosePush) and `desired-path` is the path where you want to output the k8s yaml definitions.
 
 [MIM]: https://github.com/esl/MongooseIM
-[MIM-docker]: https://hub.docker.com/r/mongooseim/mongooseim/
+[MIM-docker]: https://hub.docker.com/r/erlangsolutions/mongooseim/
 [MPush-docker]: https://hub.docker.com/r/mongooseim/mongoose-push
 [sts]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/


### PR DESCRIPTION
- We are moving the docker image from [mongooseim/mongooseim](https://hub.docker.com/repository/docker/mongooseim/mongooseim/general) (free tier) to [erlangsolutions/mongooseim](https://hub.docker.com/repository/docker/erlangsolutions/mongooseim/general) (paid tier).
- `mongoose_metrics` are replaced with `mongoose_instrument`, which has different config options. Enable `prometheus` and `log` handlers, just like in the default `prod` config file.