### PR TITLE
Update MIM to 6.3.2

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.4.3
-appVersion: 6.3.1
+version: 0.4.4
+appVersion: 6.3.2
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/MongooseIM/templates/NOTES.txt
+++ b/MongooseIM/templates/NOTES.txt
@@ -15,4 +15,4 @@ To learn more about the release, try:
 
 Or go to https://github.com/esl/MongooseIM
 
-(c) 2024 Erlang Solutions Ltd.
+(c) 2025 Erlang Solutions Ltd.

--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -141,11 +141,11 @@ run_amoc(SessionCount) ->
     run("kubectl cp _build/amoc_args.cfg " ++ Pod ++ ":/tmp/amoc_args.cfg"),
     %% Wait for for Erlang VM to start
     run_wait("kubectl exec -t " ++ Pod ++ " -- "
-             "/amoc_arsenal_xmpp/_build/default/rel/amoc_arsenal_xmpp/bin/amoc_arsenal_xmpp "
+             "/amoc_arsenal_xmpp/_build/prod/rel/amoc_arsenal_xmpp/bin/amoc_arsenal_xmpp "
              "rpc os timestamp \"[]\""),
     run("kubectl exec -t " ++ Pod ++ " -- "
         "bash -c '"
-        "/amoc_arsenal_xmpp/_build/default/rel/amoc_arsenal_xmpp/bin/amoc_arsenal_xmpp "
+        "/amoc_arsenal_xmpp/_build/prod/rel/amoc_arsenal_xmpp/bin/amoc_arsenal_xmpp "
         "rpc amoc do $(cat /tmp/amoc_args.cfg)'"),
     wait_for_session_count("mongooseim-0", SessionCount).
 


### PR DESCRIPTION
This PR updates the MIM chart version to 6.3.2, as well as the copyright year to 2025.

It also fixes the issue with the `amoc_arsenal_xmpp` path in the tests.

```
% kubectl get pods
NAME           READY   STATUS    RESTARTS   AGE
mongooseim-0   1/1     Running   0          40s
mongooseim-1   1/1     Running   0          2m14s
mongooseim-2   1/1     Running   0          102s
% kubectl exec mongooseim-1 -- /usr/lib/mongooseim/bin/mongooseimctl mnesia systemInfo --keys '["running_db_nodes"]'
{
  "data" : {
    "mnesia" : {
      "systemInfo" : [
        {
          "result" : [
            "mongooseim@mongooseim-0.mongooseim.default.svc.cluster.local",
            "mongooseim@mongooseim-2.mongooseim.default.svc.cluster.local",
            "mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local"
          ],
          "key" : "running_db_nodes"
        }
      ]
    }
  }
}
% kubectl exec mongooseim-1 -- /usr/lib/mongooseim/bin/mongooseimctl server status
{
  "data" : {
    "server" : {
      "status" : {
        "version" : "6.3.2",
        "statusCode" : "RUNNING",
        "message" : "The node 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local' is started. Status: started. MongooseIM 6.3.2 is running in that node.",
        "commitHash" : ""
      }
    }
  }
}
% kubectl exec --stdin --tty mongooseim-0 -- /bin/bash
root@mongooseim-0:/# ./lib/mongooseim/bin/mongooseim version
                                                  
      ..';:cc:,                                   
     ,ooooooo''l:'                                
      ;ooooooooool.                               
      .oooooooc,.                                 
      .oooooo:                                    
      ,oooooo,                                    
      cooooooo.                                   
     .ooooooooc                                   
     :ooooooooo.                                  
    .oooooooooooc;.                               
    'ooooooooo:,coo,                              
    :ooooooooo:..;oo.  ..                         
   .oooooooooooolcoo. :ooc                        
   ,ooooooooooooooooc .,,.     .:oo;              
   :ooooooooooooooool   ,.    .oocloc  .;ooo;     
  .loooooooooooooooo:   'ol'  .oo..oo;;oo;,co:    
  .ooooooooooooooooo,    ,oo: .oo. :oool.  .oo.   
  .ooooooooollooooool.    loo..lo. .cl:.   'ol.   
  .looooc.     ..,loooc. .ooo' ..          .'.    
   'oooo.          ..''..looc                     
    ;oool,..       ...;cooo:                      
     .;cooooollllloooool;..                       
         ..'',,;;,,'..                            
                                                  
MongooseIM version 6.3.2
```