### PR TITLE
Update MIM to 6.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw*
 # *.tgz - do not ignore files that are committed to the 'packages' branch
 .DS_Store
+_build

--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.4.4
-appVersion: 6.3.2
+version: 0.4.5
+appVersion: 6.3.3
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -40,7 +40,7 @@ end_per_group(_, Config) ->
 tag() ->
     %% You can specify a docker tag to test using:
     %% "PR-4185".
-    "latest".
+    "6.3.3".
 
 helm_args(N, Driver) ->
     #{"image.tag" => tag(),

--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -234,10 +234,10 @@ get_schema(pgsql) ->
     run("curl https://raw.githubusercontent.com/esl/MongooseIM/master/priv/pg.sql -o _build/pg.sql").
 
 psql(Args) ->
-    "kubectl exec ct-pg-postgresql-0 -- sh -c 'PGPASSWORD=$POSTGRES_PASSWORD psql " ++ Args ++ "'".
+    "kubectl exec ct-pg-postgresql-0 -- sh -c \"PGPASSWORD=$(kubectl get secret ct-pg-postgresql -o jsonpath='{.data.postgres-password}' | base64 -d) psql " ++ Args ++ "\"".
 
 run_psql_query(Query) ->
-    run(psql(" -U postgres -d mongooseim -c \"" ++ Query ++ "\"")).
+    run(psql(" -U postgres -d mongooseim -c '" ++ Query ++ "'")).
 
 cmd(Cmd) ->
    cmd(Cmd, #{}).


### PR DESCRIPTION
This PR updates the MongooseIM Helm chart to version 6.3.3 and also includes the following changes:

1. Temporarily sets the testing tag to `6.3.3` instead of `latest`, since the current master build includes updates that require changes to the config file. This PR focuses on version 6.3.3. Updating the config and reverting the tag back to `latest` can be done in a separate PR.
2. Modifies the way the PostgreSQL password is provided to the Helm container, as the previous method that was using the `$POSTGRES_PASSWORD` environment variable no longer works. The PostgreSQL password is provided via a Kubernetes Secret, which is created by the Helm chart [here](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/templates/secrets.yaml#L45-L50). The password is retrieved as shown in the [installation notes](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/templates/NOTES.txt#L64).
4. Adds the `_build` directory (created during test runs) to `.gitignore`.