### PR TITLE
Update MIM to 6.4.0

### DIFF
--- a/MongooseIM/Chart.yaml
+++ b/MongooseIM/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - chat
   - erlang
 type: application
-version: 0.4.5
-appVersion: 6.3.3
+version: 0.4.6
+appVersion: 6.4.0
 home: https://github.com/esl/MongooseIM
 icon: https://github.com/esl/MongooseIM/blob/master/doc/MongooseIM_logo.png
 maintainers:

--- a/MongooseIM/configs/mongooseim.toml
+++ b/MongooseIM/configs/mongooseim.toml
@@ -11,7 +11,6 @@
   sm_backend = "{{ .Values.volatileDatabase }}"
   component_backend = "{{ .Values.volatileDatabase }}"
   s2s_backend = "{{ .Values.volatileDatabase }}"
-  max_fsm_queue = 1000
 
 [[listen.http]]
   port = 5280
@@ -113,7 +112,7 @@
 [[listen.c2s]]
   port = 5222
   access = "c2s"
-  shaper = "c2s_shaper"
+  shaper = "normal"
   max_stanza_size = 65536
   tls.verify_mode = "none"
   tls.certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
@@ -121,7 +120,7 @@
 [[listen.c2s]]
   port = 5223
   access = "c2s"
-  shaper = "c2s_shaper"
+  shaper = "normal"
   max_stanza_size = 65536
   tls.mode = "tls"
   tls.verify_mode = "none"
@@ -129,13 +128,13 @@
 
 [[listen.s2s]]
   port = 5269
-  shaper = "s2s_shaper"
+  shaper = "fast"
   max_stanza_size = 131072
 
-[[listen.service]]
+[[listen.component]]
   port = 8888
   access = "all"
-  shaper_rule = "fast"
+  shaper = "fast"
   ip_address = "127.0.0.1"
   password = "secret"
 
@@ -261,15 +260,6 @@
     {acl = "all", value = "allow"}
   ]
 
-  c2s_shaper = [
-    {acl = "admin", value = "none"},
-    {acl = "all", value = "normal"}
-  ]
-
-  s2s_shaper = [
-    {acl = "all", value = "fast"}
-  ]
-
   muc_admin = [
     {acl = "admin", value = "allow"}
   ]
@@ -323,10 +313,13 @@
   ]
 
 [s2s]
-  use_starttls = "optional"
-  certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
   default_policy = "deny"
-  outgoing.port = 5269
+
+[s2s.outgoing]
+  port = 5269
+
+  [s2s.outgoing.tls]
+    certfile = "priv/ssl/{{ .Values.certs.fullChainWithKey }}"
 
 #[[host_config]]
 #  host = "anonymous.localhost"

--- a/test/mim_kind_SUITE.erl
+++ b/test/mim_kind_SUITE.erl
@@ -40,7 +40,7 @@ end_per_group(_, Config) ->
 tag() ->
     %% You can specify a docker tag to test using:
     %% "PR-4185".
-    "6.3.3".
+    "6.4.0".
 
 helm_args(N, Driver) ->
     #{"image.tag" => tag(),


### PR DESCRIPTION
This PR updates the MongooseIM Helm chart to use version 6.4.0.

```
% kubectl exec mongooseim-1 -- /usr/lib/mongooseim/bin/mongooseimctl server status
{
  "data" : {
    "server" : {
      "status" : {
        "version" : "6.4.0",
        "statusCode" : "RUNNING",
        "message" : "The node 'mongooseim@mongooseim-1.mongooseim.default.svc.cluster.local' is started. Status: started. MongooseIM 6.4.0 is running in that node.",
        "commitHash" : ""
      }
    }
  }
}
% kubectl exec --stdin --tty mongooseim-0 -- /bin/bash
root@mongooseim-0:/# ./lib/mongooseim/bin/mongooseim version
                                                  
      ..';:cc:,                                   
     ,ooooooo''l:'                                
      ;ooooooooool.                               
      .oooooooc,.                                 
      .oooooo:                                    
      ,oooooo,                                    
      cooooooo.                                   
     .ooooooooc                                   
     :ooooooooo.                                  
    .oooooooooooc;.                               
    'ooooooooo:,coo,                              
    :ooooooooo:..;oo.  ..                         
   .oooooooooooolcoo. :ooc                        
   ,ooooooooooooooooc .,,.     .:oo;              
   :ooooooooooooooool   ,.    .oocloc  .;ooo;     
  .loooooooooooooooo:   'ol'  .oo..oo;;oo;,co:    
  .ooooooooooooooooo,    ,oo: .oo. :oool.  .oo.   
  .ooooooooollooooool.    loo..lo. .cl:.   'ol.   
  .looooc.     ..,loooc. .ooo' ..          .'.    
   'oooo.          ..''..looc                     
    ;oool,..       ...;cooo:                      
     .;cooooollllloooool;..                       
         ..'',,;;,,'..                            
                                                  
MongooseIM version 6.4.0
```